### PR TITLE
Remove overlaps

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,5 @@ sqlalchemy>=1.4.34
 
 # Printing
 wasabi>=0.9.1
+
+git+https://github.com/Aarhus-Psychiatry-Research/psycop-ml-utils.git

--- a/src/application/create_train_test_split.py
+++ b/src/application/create_train_test_split.py
@@ -13,6 +13,7 @@ from wasabi import msg
 
 from pathlib import Path
 
+
 def load_patient_ids(view="FOR_kohorte_demografi_inkl_2021_feb2022"):
     view = f"{view}"
     query = "SELECT * FROM [fct]." + view

--- a/src/application/create_train_test_split.py
+++ b/src/application/create_train_test_split.py
@@ -11,6 +11,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.pool import NullPool
 from wasabi import msg
 
+from pathlib import Path
 
 def load_patient_ids(view="FOR_kohorte_demografi_inkl_2021_feb2022"):
     view = f"{view}"
@@ -36,6 +37,10 @@ def load_patient_ids(view="FOR_kohorte_demografi_inkl_2021_feb2022"):
 
 
 if __name__ == "__main__":
+
+    OUTCOME_ID_PATH = Path(
+        "\\\\TSCLIENT\\P\\MANBER01\\documentLibrary\\train-test-splits\\outcome_ids"
+    )
     outcomes = [
         "transition_to_schizophrenia",
         "inpatient_forced_admissions",
@@ -59,7 +64,7 @@ if __name__ == "__main__":
     for outcome in outcomes:
         combined_df = add_outcome_from_csv(
             df_in=combined_df,
-            df_outcome_path=f"outcome_ids/{outcome}.csv",
+            df_outcome_path=OUTCOME_ID_PATH / (outcome + ".csv"),
             new_colname=outcome,
             id_colname="dw_ek_borger",
         )

--- a/src/application/write_to_sql.py
+++ b/src/application/write_to_sql.py
@@ -19,5 +19,3 @@ if __name__ == "__main__":
             df, table_name=table_name, rows_per_chunk=5000, if_exists="replace"
         )
 
-
-# set default row per chunk to 5000

--- a/src/application/write_to_sql.py
+++ b/src/application/write_to_sql.py
@@ -18,4 +18,3 @@ if __name__ == "__main__":
         write_df_to_sql(
             df, table_name=table_name, rows_per_chunk=5000, if_exists="replace"
         )
-

--- a/src/application/write_to_sql.py
+++ b/src/application/write_to_sql.py
@@ -1,0 +1,23 @@
+from psycopmlutils.writers.sql_writer import write_df_to_sql
+
+import pandas as pd
+from pathlib import Path
+
+
+def load_split(split):
+    return pd.read_csv(SPLIT_PATH / (f"{split}_ids.csv"))
+
+
+if __name__ == "__main__":
+
+    SPLIT_PATH = Path(__file__).parent.parent.parent / "splits"
+
+    for split in ["train", "val", "test"]:
+        df = load_split(split)
+        table_name = f"[psycop_{split}_ids]"
+        write_df_to_sql(
+            df, table_name=table_name, rows_per_chunk=5000, if_exists="replace"
+        )
+
+
+# set default row per chunk to 5000

--- a/src/psycoptts/add_outcomes.py
+++ b/src/psycoptts/add_outcomes.py
@@ -2,8 +2,8 @@ import pandas as pd
 
 
 def add_outcome_from_df(df_in, df_outcome, new_col_name, id_colname="dw_ek_borger"):
+    df_outcome = df_outcome.drop_duplicates()
     df_outcome[new_col_name] = 1
-
     return pd.merge(df_in, df_outcome, how="left", on=id_colname).fillna(0)
 
 

--- a/tests/test_id_overlap.py
+++ b/tests/test_id_overlap.py
@@ -1,7 +1,7 @@
-import pytest
+from pathlib import Path
 
 import pandas as pd
-from pathlib import Path
+import pytest
 
 SPLIT_PATH = Path(__file__).parent.parent / "splits"
 
@@ -12,6 +12,9 @@ def _load_split(split: str):
 
 def test_overlap():
     """Check for overlapping ids in splits"""
+    if not SPLIT_PATH.exists():
+        pytest.skip(reason="No splits directory")
+
     train = _load_split("train")
     val = _load_split("val")
     test = _load_split("test")

--- a/tests/test_id_overlap.py
+++ b/tests/test_id_overlap.py
@@ -3,11 +3,12 @@ import pytest
 import pandas as pd
 from pathlib import Path
 
-SPLIT_PATH = Path(__file__).parent / "splits"
+SPLIT_PATH = Path(__file__).parent.parent / "splits"
 
 
 def _load_split(split: str):
     return pd.read_csv(SPLIT_PATH / f"{split}_ids.csv")["dw_ek_borger"]
+
 
 def test_overlap():
     """Check for overlapping ids in splits"""
@@ -15,5 +16,5 @@ def test_overlap():
     val = _load_split("val")
     test = _load_split("test")
 
-    assert val[val.isin[train]].empty
-    assert test[test.isin[train]].empty 
+    assert val[val.isin(train)].empty
+    assert test[test.isin(train)].empty

--- a/tests/test_id_overlap.py
+++ b/tests/test_id_overlap.py
@@ -1,0 +1,19 @@
+import pytest
+
+import pandas as pd
+from pathlib import Path
+
+SPLIT_PATH = Path(__file__).parent / "splits"
+
+
+def _load_split(split: str):
+    return pd.read_csv(SPLIT_PATH / f"{split}_ids.csv")["dw_ek_borger"]
+
+def test_overlap():
+    """Check for overlapping ids in splits"""
+    train = _load_split("train")
+    val = _load_split("val")
+    test = _load_split("test")
+
+    assert val[val.isin[train]].empty
+    assert test[test.isin[train]].empty 


### PR DESCRIPTION
Drops duplicates from outcome dfs (the ids from each project) which led to overlapping ids in the splits